### PR TITLE
Fix settings modal button layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -500,7 +500,7 @@
 
     <div id="settingsModal" class="fixed inset-0 bg-black bg-opacity-50 hidden z-50">
         <div class="flex items-center justify-center h-full p-4">
-            <div class="bg-custom w-full max-w-sm rounded-xl border border-gray-700 flex flex-col max-h-[90vh]">
+            <div class="bg-custom w-full max-w-sm rounded-xl border border-gray-700 flex flex-col max-h-[90vh] h-full">
                 <!-- Settings Header -->
                 <div class="flex justify-center items-center p-6 pb-4">
                     <h2 class="text-xl font-bold uppercase">SETTINGS</h2>
@@ -619,7 +619,7 @@
                 </div>
                 
                 <!-- Fixed Bottom Buttons -->
-                <div class="flex w-full border-t border-gray-600">
+                <div class="flex w-full border-t border-gray-600 mt-auto">
                     <button id="cancelSettings" class="flex-1 px-4 py-3 text-gray-400 hover:text-gray-300 transition-all hover-stroke saber-glow button uppercase">
                         CANCEL
                     </button>


### PR DESCRIPTION
## Summary
- Ensure settings modal fills available height
- Anchor Save/Cancel button group at bottom of settings modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68953bd6ee3c8332b2f7f7b5f81a204e